### PR TITLE
Add environment variables for user data similar to team data

### DIFF
--- a/src/services/Op.ts
+++ b/src/services/Op.ts
@@ -220,6 +220,8 @@ export class OpService {
       OPS_OP_NAME: op.name,
       OPS_TEAM_ID: config.team.id,
       OPS_TEAM_NAME: config.team.name,
+      OPS_USER_NAME: config.user.username,
+      OPS_USER_EMAIL: config.user.email,
       OPS_HOST_PLATFORM: os.platform(),
     }
 


### PR DESCRIPTION
It could be beneficial to have the current user's data (name and email) available in the running Op as env variables (OPS_USER_NAME and OPS_USER_EMAIL) so they can be used to identify the running user in other 3rd party services (e.g. an Op for fetching assigned MRs in github/gitlab for instance)